### PR TITLE
Create /dev/null in new root to prevent hangs

### DIFF
--- a/pacstrap-docker
+++ b/pacstrap-docker
@@ -19,7 +19,13 @@ mkdir -m 0755 -p "$newroot"/var/{cache/pacman/pkg,lib/pacman,log} "$newroot"/{de
 mkdir -m 1777 -p "$newroot"/tmp
 mkdir -m 0555 -p "$newroot"/{sys,proc}
 
+echo 'Creating /dev/null in new root'
+mknod "$newroot/dev/null" c 1 3
+
 echo 'Installing packages to %s' "$newroot"
 if ! pacman -r "$newroot" -Sy --noconfirm "${pacman_args[@]}"; then
 	die 'Failed to install packages to new root'
 fi
+
+echo 'Deleting /dev/null from new root'
+rm "$newroot/dev/null"


### PR DESCRIPTION
gnupg post install script does `dirmngr </dev/null &>/dev/null`.

Since `pacman -r` does not mount any filesystems but it does chroot into the new root to install the new packages, `/dev/null` does not exist, making the script hang forever.

This patch creates `$newroot/dev/null` before running `pacman`, and then removes it to prevent any issues.